### PR TITLE
Pin holoviews

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_setup_version(reponame):
 install_requires = [
     'bokeh >=1.0.0',
     'colorcet >=2',
-    'holoviews >=1.11.0',
+    'holoviews >=1.15.0',
     'pandas',
     'numpy>=1.15',
     'packaging',


### PR DESCRIPTION
<details>

<summary><code>mamba install hvplot</code> </summary>


``` yaml
conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
Transaction

  Prefix: /home/shh/miniconda3/envs/tmp4

  Updating specs:

   - hvplot
   - ca-certificates
   - openssl


  Package                 Version  Build                Channel                    Size
─────────────────────────────────────────────────────────────────────────────────────────
  Install:
─────────────────────────────────────────────────────────────────────────────────────────

  + bokeh                   3.0.2  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + brotli                  1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + brotli-bin              1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + brotlipy                0.7.0  py310h5764c6d_1005   conda-forge/linux-64     Cached
  + certifi             2022.9.24  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + cffi                   1.15.1  py310h255011f_2      conda-forge/linux-64     Cached
  + charset-normalizer      2.1.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + colorama                0.4.6  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + colorcet                3.0.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + contourpy               1.0.6  py310hbf28c38_0      conda-forge/linux-64     Cached
  + cryptography           38.0.3  py310h600f1e7_0      conda-forge/linux-64     Cached
  + cycler                 0.11.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + fonttools              4.38.0  py310h5764c6d_1      conda-forge/linux-64     Cached
  + freetype               2.12.1  hca18f0e_0           conda-forge/linux-64     Cached
  + holoviews              1.14.9  pyhd8ed1ab_0         conda-forge/noarch          4MB
  + hvplot                  0.8.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + idna                      3.4  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + importlib-metadata      5.0.0  pyha770c72_1         conda-forge/noarch       Cached
  + jinja2                  3.1.2  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + jpeg                       9e  h166bdaf_2           conda-forge/linux-64     Cached
  + kiwisolver              1.4.4  py310hbf28c38_1      conda-forge/linux-64     Cached
  + lcms2                    2.14  h6ed2654_0           conda-forge/linux-64     Cached
  + lerc                    4.0.0  h27087fc_0           conda-forge/linux-64     Cached
  + libblas                 3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libbrotlicommon         1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libbrotlidec            1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libbrotlienc            1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libcblas                3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libdeflate               1.14  h166bdaf_0           conda-forge/linux-64     Cached
  + libgfortran-ng         12.2.0  h69a702a_19          conda-forge/linux-64     Cached
  + libgfortran5           12.2.0  h337968e_19          conda-forge/linux-64     Cached
  + liblapack               3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libopenblas            0.3.21  pthreads_h78a6416_3  conda-forge/linux-64     Cached
  + libpng                 1.6.38  h753d276_0           conda-forge/linux-64     Cached
  + libstdcxx-ng           12.2.0  h46fd767_19          conda-forge/linux-64     Cached
  + libtiff                 4.4.0  h55922b4_4           conda-forge/linux-64     Cached
  + libwebp-base            1.2.4  h166bdaf_0           conda-forge/linux-64     Cached
  + libxcb                   1.13  h7f98852_1004        conda-forge/linux-64     Cached
  + markdown                3.4.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + markupsafe              2.1.1  py310h5764c6d_2      conda-forge/linux-64     Cached
  + matplotlib-base         3.6.2  py310h8d5ebf3_0      conda-forge/linux-64     Cached
  + munkres                 1.1.4  pyh9f0ad1d_0         conda-forge/noarch       Cached
  + numpy                  1.23.4  py310h53a5b5f_1      conda-forge/linux-64     Cached
  + openjpeg                2.5.0  h7d73246_1           conda-forge/linux-64     Cached
  + packaging                21.3  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pandas                  1.5.1  py310h769672d_1      conda-forge/linux-64     Cached
  + panel                  0.10.3  pyhd8ed1ab_0         conda-forge/noarch          6MB
  + param                  1.12.2  pyh6c4a22f_0         conda-forge/noarch       Cached
  + pillow                  9.2.0  py310h454ad03_3      conda-forge/linux-64     Cached
  + pthread-stubs             0.4  h36c2ea0_1001        conda-forge/linux-64     Cached
  + pycparser                2.21  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyct                    0.4.6  py_0                 conda-forge/noarch       Cached
  + pyct-core               0.4.6  py_0                 conda-forge/noarch       Cached
  + pyopenssl              22.1.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyparsing               3.0.9  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pysocks                 1.7.1  pyha2e5f31_6         conda-forge/noarch       Cached
  + python-dateutil         2.8.2  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + python_abi               3.10  2_cp310              conda-forge/linux-64     Cached
  + pytz                   2022.6  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyviz_comms             2.2.1  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + pyyaml                    6.0  py310h5764c6d_5      conda-forge/linux-64     Cached
  + requests               2.28.1  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + six                    1.16.0  pyh6c4a22f_0         conda-forge/noarch       Cached
  + tornado                   6.2  py310h5764c6d_1      conda-forge/linux-64     Cached
  + tqdm                   4.64.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + unicodedata2           15.0.0  py310h5764c6d_0      conda-forge/linux-64     Cached
  + urllib3               1.26.11  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + xorg-libxau             1.0.9  h7f98852_0           conda-forge/linux-64     Cached
  + xorg-libxdmcp           1.1.3  h7f98852_0           conda-forge/linux-64     Cached
  + xyzservices          2022.9.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + yaml                    0.2.5  h7f98852_2           conda-forge/linux-64     Cached
  + zipp                   3.10.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + zstd                    1.5.2  h6239696_4           conda-forge/linux-64     Cached

  Summary:

  Install: 73 packages

  Total download: 10MB

─────────────────────────────────────────────────────────────────────────────────────────

Confirm changes: [Y/n] Aborted.

Looking for: ['hvplot']


Pinned packages:
  - python 3.10.*


```


</details>


<details>

<summary><code>mamba install hvplot "holoviews>=1.15" </code></summary>


``` yaml
conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
Transaction

  Prefix: /home/shh/miniconda3/envs/tmp4

  Updating specs:

   - hvplot
   - holoviews[version='>=1.15']
   - ca-certificates
   - openssl


  Package                 Version  Build                Channel                    Size
─────────────────────────────────────────────────────────────────────────────────────────
  Install:
─────────────────────────────────────────────────────────────────────────────────────────

  + bleach                  5.0.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + bokeh                   2.4.3  pyhd8ed1ab_3         conda-forge/noarch       Cached
  + brotli                  1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + brotli-bin              1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + brotlipy                0.7.0  py310h5764c6d_1005   conda-forge/linux-64     Cached
  + certifi             2022.9.24  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + cffi                   1.15.1  py310h255011f_2      conda-forge/linux-64     Cached
  + charset-normalizer      2.1.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + colorama                0.4.6  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + colorcet                3.0.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + contourpy               1.0.6  py310hbf28c38_0      conda-forge/linux-64     Cached
  + cryptography           38.0.3  py310h600f1e7_0      conda-forge/linux-64     Cached
  + cycler                 0.11.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + fonttools              4.38.0  py310h5764c6d_1      conda-forge/linux-64     Cached
  + freetype               2.12.1  hca18f0e_0           conda-forge/linux-64     Cached
  + holoviews              1.15.2  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + hvplot                  0.8.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + idna                      3.4  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + importlib-metadata      5.0.0  pyha770c72_1         conda-forge/noarch       Cached
  + jinja2                  3.1.2  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + jpeg                       9e  h166bdaf_2           conda-forge/linux-64     Cached
  + kiwisolver              1.4.4  py310hbf28c38_1      conda-forge/linux-64     Cached
  + lcms2                    2.14  h6ed2654_0           conda-forge/linux-64     Cached
  + lerc                    4.0.0  h27087fc_0           conda-forge/linux-64     Cached
  + libblas                 3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libbrotlicommon         1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libbrotlidec            1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libbrotlienc            1.0.9  h166bdaf_8           conda-forge/linux-64     Cached
  + libcblas                3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libdeflate               1.14  h166bdaf_0           conda-forge/linux-64     Cached
  + libgfortran-ng         12.2.0  h69a702a_19          conda-forge/linux-64     Cached
  + libgfortran5           12.2.0  h337968e_19          conda-forge/linux-64     Cached
  + liblapack               3.9.0  16_linux64_openblas  conda-forge/linux-64     Cached
  + libopenblas            0.3.21  pthreads_h78a6416_3  conda-forge/linux-64     Cached
  + libpng                 1.6.38  h753d276_0           conda-forge/linux-64     Cached
  + libstdcxx-ng           12.2.0  h46fd767_19          conda-forge/linux-64     Cached
  + libtiff                 4.4.0  h55922b4_4           conda-forge/linux-64     Cached
  + libwebp-base            1.2.4  h166bdaf_0           conda-forge/linux-64     Cached
  + libxcb                   1.13  h7f98852_1004        conda-forge/linux-64     Cached
  + markdown                3.4.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + markupsafe              2.1.1  py310h5764c6d_2      conda-forge/linux-64     Cached
  + matplotlib-base         3.6.2  py310h8d5ebf3_0      conda-forge/linux-64     Cached
  + munkres                 1.1.4  pyh9f0ad1d_0         conda-forge/noarch       Cached
  + numpy                  1.23.4  py310h53a5b5f_1      conda-forge/linux-64     Cached
  + openjpeg                2.5.0  h7d73246_1           conda-forge/linux-64     Cached
  + packaging                21.3  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pandas                  1.5.1  py310h769672d_1      conda-forge/linux-64     Cached
  + panel                  0.14.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + param                  1.12.2  pyh6c4a22f_0         conda-forge/noarch       Cached
  + pillow                  9.2.0  py310h454ad03_3      conda-forge/linux-64     Cached
  + pthread-stubs             0.4  h36c2ea0_1001        conda-forge/linux-64     Cached
  + pycparser                2.21  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyct                    0.4.6  py_0                 conda-forge/noarch       Cached
  + pyct-core               0.4.6  py_0                 conda-forge/noarch       Cached
  + pyopenssl              22.1.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyparsing               3.0.9  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pysocks                 1.7.1  pyha2e5f31_6         conda-forge/noarch       Cached
  + python-dateutil         2.8.2  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + python_abi               3.10  2_cp310              conda-forge/linux-64     Cached
  + pytz                   2022.6  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + pyviz_comms             2.2.1  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + pyyaml                    6.0  py310h5764c6d_5      conda-forge/linux-64     Cached
  + requests               2.28.1  pyhd8ed1ab_1         conda-forge/noarch       Cached
  + six                    1.16.0  pyh6c4a22f_0         conda-forge/noarch       Cached
  + tornado                   6.2  py310h5764c6d_1      conda-forge/linux-64     Cached
  + tqdm                   4.64.1  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + typing_extensions       4.4.0  pyha770c72_0         conda-forge/noarch       Cached
  + unicodedata2           15.0.0  py310h5764c6d_0      conda-forge/linux-64     Cached
  + urllib3               1.26.11  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + webencodings            0.5.1  py_1                 conda-forge/noarch       Cached
  + xorg-libxau             1.0.9  h7f98852_0           conda-forge/linux-64     Cached
  + xorg-libxdmcp           1.1.3  h7f98852_0           conda-forge/linux-64     Cached
  + yaml                    0.2.5  h7f98852_2           conda-forge/linux-64     Cached
  + zipp                   3.10.0  pyhd8ed1ab_0         conda-forge/noarch       Cached
  + zstd                    1.5.2  h6239696_4           conda-forge/linux-64     Cached

  Summary:

  Install: 75 packages

  Total download: 0 B

─────────────────────────────────────────────────────────────────────────────────────────

Confirm changes: [Y/n] Aborted.

Looking for: ['hvplot', "holoviews[version='>=1.15']"]


Pinned packages:
  - python 3.10.*

```


</details>